### PR TITLE
Replace digit repeat character

### DIFF
--- a/src/CronLint.php
+++ b/src/CronLint.php
@@ -149,7 +149,7 @@ class CronLint extends Plugin implements ZeroConfigPluginInterface
         list($mins, $hours, $dayofmonth, $month, $dayofweek) = array_slice($args, 0, 5);
 
         $regEx = [
-            'minhour'     => '/^([\*|\d])$|^([\*|\d]+?(\-\d+))$|^([\*]\/\d+)$|^([\d+]\/\d+?(\-\d+))$|^(\d+-\d+\/[\d]+)$/i',
+            'minhour'     => '/^([\*|\d]+)$|^([\*|\d]+?(\-\d+))$|^([\*]\/\d+)$|^([\d+]\/\d+?(\-\d+))$|^(\d+-\d+\/[\d]+)$/i',
             'daymonth'    => '/^(\d|\*)$/i',
             'month'       => '/^(\d|\*)$/i',
             'dayweek'     => '/^(\*|\d|[a-z]{3})$/i',


### PR DESCRIPTION
Whoops! Removed a `+` from the original regex accidently. Adding it back in.